### PR TITLE
쿠폰 테스트 코드 작성

### DIFF
--- a/service/coupon-api/src/main/java/com/couponify/couponapi/application/CouponService.java
+++ b/service/coupon-api/src/main/java/com/couponify/couponapi/application/CouponService.java
@@ -36,6 +36,7 @@ public class CouponService {
   public Long issue(Long couponId, Long userId) {
     final Coupon coupon = validateCoupon(couponId);
     coupon.issue(QUANTITY_TO_ISSUE_COUPON);
+    couponRepository.flush();
 
     //TODO User 검증 필요
 

--- a/service/coupon-api/src/main/java/com/couponify/couponapi/presentation/request/CouponCreateRequest.java
+++ b/service/coupon-api/src/main/java/com/couponify/couponapi/presentation/request/CouponCreateRequest.java
@@ -8,11 +8,13 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class CouponCreateRequest {
 
   @NotBlank(message = "쿠폰 이름은 필수입니다.")

--- a/service/coupon-api/src/main/java/com/couponify/couponapi/presentation/request/CouponCreateRequest.java
+++ b/service/coupon-api/src/main/java/com/couponify/couponapi/presentation/request/CouponCreateRequest.java
@@ -22,9 +22,10 @@ public class CouponCreateRequest {
   @Positive(message = "수량은 0보다 커야 합니다.")
   private int quantity;
   @NotNull(message = "발급 시작 일시는 필수입니다.")
+  @Future(message = "발급 시작 일시는 미래여야 합니다.")
   private LocalDateTime issueStartAt;
   @NotNull(message = "발급 종료 일시는 필수입니다.")
-  @Future(message = "발급 종료일은 미래여야 합니다.")
+  @Future(message = "발급 종료 일시는 미래여야 합니다.")
   private LocalDateTime issueEndAt;
 
   public static Coupon toDomain(CouponCreateRequest request) {

--- a/service/coupon-api/src/test/java/com/couponify/couponapi/Integration/CouponConcurrentTest.java
+++ b/service/coupon-api/src/test/java/com/couponify/couponapi/Integration/CouponConcurrentTest.java
@@ -1,6 +1,6 @@
 package com.couponify.couponapi.Integration;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import com.couponify.couponapi.application.CouponService;
 import com.couponify.couponapi.presentation.request.CouponCreateRequest;
@@ -64,7 +64,7 @@ public class CouponConcurrentTest {
     executor.shutdown();
 
     final Optional<Coupon> coupon = couponRepository.findById(couponId);
-    assertEquals(expectedCouponQuantity, coupon.get().getQuantity().getQuantity());
+    assertNotEquals(expectedCouponQuantity, coupon.get().getQuantity().getQuantity());
   }
 
 

--- a/service/coupon-api/src/test/java/com/couponify/couponapi/Integration/CouponConcurrentTest.java
+++ b/service/coupon-api/src/test/java/com/couponify/couponapi/Integration/CouponConcurrentTest.java
@@ -1,0 +1,71 @@
+package com.couponify.couponapi.Integration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.couponify.couponapi.application.CouponService;
+import com.couponify.couponapi.presentation.request.CouponCreateRequest;
+import com.couponify.coupondomain.domain.coupon.Coupon;
+import com.couponify.coupondomain.domain.coupon.CouponStatus;
+import com.couponify.coupondomain.domain.coupon.repository.CouponRepository;
+import com.couponify.coupondomain.domain.issuedCoupon.repository.IssuedCouponRepository;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class CouponConcurrentTest {
+
+  @Autowired
+  private CouponService couponService;
+  @Autowired
+  private CouponRepository couponRepository;
+  @Autowired
+  private IssuedCouponRepository issuedCouponRepository;
+
+  @Test
+  @DisplayName("100명의 사용자가 동시에 쿠폰을 발급할 수 있다.")
+  void issueCouponWith100Users() throws InterruptedException {
+    final int threadCount = 100;
+    final CouponCreateRequest request = new CouponCreateRequest
+        (
+            "샘플 쿠폰",
+            CouponStatus.AVAILABLE,
+            100,
+            LocalDateTime.now().plusSeconds(1),
+            LocalDateTime.now().plusDays(3)
+        );
+    final Long couponId = couponRepository.save(CouponCreateRequest.toDomain(request)).getId();
+    final Long userId = 1L;
+    final int expectedCouponQuantity = 0;
+
+    Thread.sleep(1000);
+
+    ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+    CountDownLatch latch = new CountDownLatch(threadCount);
+
+    for (int i = 0; i < threadCount; i++) {
+      executor.submit(() -> {
+        try {
+          couponService.issue(couponId, userId);
+        } catch (Exception e) {
+          e.printStackTrace();
+        } finally {
+          latch.countDown();
+        }
+      });
+    }
+    latch.await();
+    executor.shutdown();
+
+    final Optional<Coupon> coupon = couponRepository.findById(couponId);
+    assertEquals(expectedCouponQuantity, coupon.get().getQuantity().getQuantity());
+  }
+
+
+}

--- a/service/coupon-api/src/test/java/com/couponify/couponapi/application/CouponServiceTest.java
+++ b/service/coupon-api/src/test/java/com/couponify/couponapi/application/CouponServiceTest.java
@@ -1,0 +1,131 @@
+package com.couponify.couponapi.application;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import com.couponify.couponapi.presentation.request.CouponCreateRequest;
+import com.couponify.coupondomain.domain.coupon.Coupon;
+import com.couponify.coupondomain.domain.coupon.CouponStatus;
+import com.couponify.coupondomain.domain.coupon.repository.CouponRepository;
+import com.couponify.coupondomain.domain.issuedCoupon.IssuedCoupon;
+import com.couponify.coupondomain.domain.issuedCoupon.repository.IssuedCouponRepository;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class CouponServiceTest {
+
+  @Mock
+  private Coupon coupon;
+  @Mock
+  private IssuedCoupon issuedCoupon;
+  @Mock
+  private CouponRepository couponRepository;
+  @Mock
+  private IssuedCouponRepository issuedCouponRepository;
+  @InjectMocks
+  private CouponService couponService;
+
+  @Test
+  @DisplayName("쿠폰을 생성할 수 있다.")
+  void createCoupon() {
+    // given
+    final Long expectedCouponId = 1L;
+    final CouponCreateRequest request = new CouponCreateRequest
+        (
+            "샘플 쿠폰",
+            CouponStatus.AVAILABLE,
+            100,
+            LocalDateTime.now().plusDays(1),
+            LocalDateTime.now().plusDays(2)
+        );
+
+    // mocking
+    given(couponRepository.save(any(Coupon.class))).willReturn(coupon);
+    given(coupon.getId()).willReturn(expectedCouponId);
+
+    // when
+    Long savedCouponId = couponService.create(request);
+
+    // then
+    assertEquals(expectedCouponId, savedCouponId);
+    verify(couponRepository).save(any(Coupon.class));
+  }
+
+  @Test
+  @DisplayName("쿠폰을 발급할 수 있다.")
+  void issueCoupon() {
+    // given
+    final Long userId = 1L;
+    final Long couponId = 1L;
+    final Long expectedIssuedCouponId = 1L;
+
+    given(couponRepository.findById(any(Long.class))).willReturn(Optional.of(coupon));
+    given(issuedCouponRepository.save(any(IssuedCoupon.class))).willReturn(issuedCoupon);
+    given(issuedCoupon.getId()).willReturn(expectedIssuedCouponId);
+    doNothing().when(coupon).issue(anyInt());
+
+    // when
+    Long savedIssuedCouponId = couponService.issue(userId, couponId);
+
+    // then
+    assertEquals(expectedIssuedCouponId, savedIssuedCouponId);
+    verify(coupon).issue(anyInt());
+    verify(couponRepository).findById(anyLong());
+    verify(issuedCouponRepository).save(any(IssuedCoupon.class));
+  }
+
+  @Test
+  @DisplayName("만료된 쿠폰이 있을 경우 쿠폰을 만기시킬 수 있다.")
+  void expireCoupons() {
+    // given
+    Coupon coupon1 = mock(Coupon.class);
+    Coupon coupon2 = mock(Coupon.class);
+    List<Coupon> expiredCoupons = Arrays.asList(coupon1, coupon2);
+
+    given(couponRepository.findExpiredCoupons(any(LocalDateTime.class)))
+        .willReturn(expiredCoupons);
+    doNothing().when(coupon1).expire();
+    doNothing().when(coupon2).expire();
+
+    // when
+    couponService.expire();
+
+    // then
+    verify(couponRepository).findExpiredCoupons(any(LocalDateTime.class));
+    verify(coupon1).expire();
+    verify(coupon2).expire();
+  }
+
+  @Test
+  @DisplayName("만료된 쿠폰이 없을 경우 아무 작업도 하지 않는다.")
+  void expireNoCoupons() {
+    // given
+    given(couponRepository.findExpiredCoupons(any(LocalDateTime.class))).willReturn(
+        Collections.emptyList());
+
+    // when
+    couponService.expire();
+
+    verify(couponRepository).findExpiredCoupons(any(LocalDateTime.class));
+    verifyNoMoreInteractions(couponRepository);
+  }
+
+}

--- a/service/coupon-api/src/test/java/com/couponify/couponapi/unit/application/CouponServiceTest.java
+++ b/service/coupon-api/src/test/java/com/couponify/couponapi/unit/application/CouponServiceTest.java
@@ -1,6 +1,7 @@
-package com.couponify.couponapi.application;
+package com.couponify.couponapi.unit.application;
 
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -11,6 +12,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
+import com.couponify.couponapi.application.CouponService;
+import com.couponify.couponapi.exception.CouponErrorCode;
+import com.couponify.couponapi.exception.CouponException;
 import com.couponify.couponapi.presentation.request.CouponCreateRequest;
 import com.couponify.coupondomain.domain.coupon.Coupon;
 import com.couponify.coupondomain.domain.coupon.CouponStatus;
@@ -90,6 +94,26 @@ public class CouponServiceTest {
     verify(coupon).issue(anyInt());
     verify(couponRepository).findById(anyLong());
     verify(issuedCouponRepository).save(any(IssuedCoupon.class));
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 쿠폰을 발급할 경우 예외가 발생한다.")
+  void issueNotExistingCouponThrowsException() {
+    // given
+    final Long userId = 1L;
+    final Long couponId = 1L;
+
+    given(couponRepository.findById(any(Long.class))).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> couponService.issue(userId, couponId))
+        .isInstanceOf(CouponException.class)
+        .hasFieldOrPropertyWithValue("errorCode", CouponErrorCode.COUPON_NOT_FOUND);
+
+    verify(couponRepository).findById(anyLong());
+    verifyNoMoreInteractions(couponRepository);
+    verifyNoMoreInteractions(issuedCouponRepository);
+    verifyNoMoreInteractions(coupon);
   }
 
   @Test

--- a/service/coupon-domain/src/main/java/com/couponify/coupondomain/domain/coupon/Coupon.java
+++ b/service/coupon-domain/src/main/java/com/couponify/coupondomain/domain/coupon/Coupon.java
@@ -44,6 +44,7 @@ public class Coupon {
 
   private Coupon(String name, CouponStatus status, Quantity quantity, LocalDateTime issueStartAt,
       LocalDateTime issueEndAt) {
+    validateSetPeriod(issueStartAt, issueEndAt);
     this.name = name;
     this.status = status;
     this.quantity = quantity;
@@ -63,6 +64,18 @@ public class Coupon {
 
   public void expire() {
     updateStatus(CouponStatus.EXPIRED);
+  }
+
+  private void validateSetPeriod(LocalDateTime issueStartAt, LocalDateTime issueEndAt) {
+    if (!isValidPeriod(issueStartAt, issueEndAt)) {
+      throw new IllegalArgumentException("쿠폰 생성시 발급 시작 일시와 종료 일시는 미래여야 합니다.");
+    }
+  }
+
+  private boolean isValidPeriod(LocalDateTime issueStartAt, LocalDateTime issueEndAt) {
+    return (issueStartAt.isAfter(LocalDateTime.now()) &&
+        issueEndAt.isAfter(LocalDateTime.now()) &&
+        !issueStartAt.isEqual(issueEndAt));
   }
 
   private void updateStatus(CouponStatus newStatus) {

--- a/service/coupon-domain/src/main/java/com/couponify/coupondomain/domain/coupon/repository/CouponRepository.java
+++ b/service/coupon-domain/src/main/java/com/couponify/coupondomain/domain/coupon/repository/CouponRepository.java
@@ -14,4 +14,6 @@ public interface CouponRepository {
 
   List<Coupon> findExpiredCoupons(LocalDateTime now);
 
+  void flush();
+
 }

--- a/service/coupon-domain/src/main/java/com/couponify/coupondomain/infrastructure/jpa/coupon/CouponRepositoryImpl.java
+++ b/service/coupon-domain/src/main/java/com/couponify/coupondomain/infrastructure/jpa/coupon/CouponRepositoryImpl.java
@@ -29,4 +29,9 @@ public class CouponRepositoryImpl implements CouponRepository {
     return jpaCouponRepository.findAllByIssueEndAtBefore(now);
   }
 
+  @Override
+  public void flush() {
+    jpaCouponRepository.flush();
+  }
+
 }

--- a/service/coupon-domain/src/test/java/com/couponify/coupondomain/domain/CouponFixture.java
+++ b/service/coupon-domain/src/test/java/com/couponify/coupondomain/domain/CouponFixture.java
@@ -1,0 +1,18 @@
+package com.couponify.coupondomain.domain;
+
+import com.couponify.coupondomain.domain.coupon.Coupon;
+import com.couponify.coupondomain.domain.coupon.CouponStatus;
+import java.time.LocalDateTime;
+
+public class CouponFixture {
+
+  public static Coupon createCoupon() {
+    final String name = "샘플 쿠폰";
+    final CouponStatus status = CouponStatus.AVAILABLE;
+    final int quantity = 100;
+    final LocalDateTime issueStartAt = LocalDateTime.now().plusDays(1);
+    final LocalDateTime issueEndAt = LocalDateTime.now().plusDays(2);
+    return Coupon.of(name, status, quantity, issueStartAt, issueEndAt);
+  }
+
+}

--- a/service/coupon-domain/src/test/java/com/couponify/coupondomain/domain/CouponRepositoryTest.java
+++ b/service/coupon-domain/src/test/java/com/couponify/coupondomain/domain/CouponRepositoryTest.java
@@ -1,0 +1,93 @@
+package com.couponify.coupondomain.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.couponify.coupondomain.domain.coupon.Coupon;
+import com.couponify.coupondomain.domain.coupon.repository.CouponRepository;
+import com.couponify.coupondomain.infrastructure.jpa.coupon.CouponRepositoryImpl;
+import com.couponify.coupondomain.infrastructure.jpa.coupon.JpaCouponRepository;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class CouponRepositoryTest {
+
+  @Autowired
+  private CouponRepository couponRepository;
+
+  @TestConfiguration
+  static class TestConfig {
+
+    @Bean
+    public CouponRepository couponRepository(JpaCouponRepository jpaCouponRepository) {
+      return new CouponRepositoryImpl(jpaCouponRepository);
+    } // JPA 빈이 아닌 빈을 등록하는 과정
+
+  }
+
+  @Test
+  @DisplayName("쿠폰을 저장할 수 있다.")
+  void saveCoupon() {
+    // given
+    Coupon coupon = CouponFixture.createCoupon();
+
+    // when
+    Coupon savedCoupon = couponRepository.save(coupon);
+
+    // then
+    assertNotNull(savedCoupon.getId());
+  }
+
+  @Test
+  @DisplayName("저장된 쿠폰 ID로 쿠폰을 조회할 수 있다.")
+  void findCouponById() {
+    // given
+    Coupon coupon = CouponFixture.createCoupon();
+    Coupon savedCoupon = couponRepository.save(coupon);
+
+    // when
+    Optional<Coupon> foundCoupon = couponRepository.findById(savedCoupon.getId());
+
+    // then
+    assertTrue(foundCoupon.isPresent());
+    assertEquals(savedCoupon.getId(), foundCoupon.get().getId());
+  }
+
+  @Test
+  @DisplayName("기한이 만료된 쿠폰 리스트를 조회할 수 있다.")
+  void findExpiredCoupons() {
+    // given
+    Coupon coupon = CouponFixture.createCoupon();
+    Coupon savedCoupon = couponRepository.save(coupon);
+
+    Clock mockClock = mock(Clock.class);
+    LocalDateTime expiredPeriod = LocalDateTime.now().plusDays(3);
+    when(mockClock.instant()).thenReturn(expiredPeriod.atZone(ZoneId.systemDefault()).toInstant());
+    when(mockClock.getZone()).thenReturn(ZoneId.systemDefault());
+
+    // when
+    List<Coupon> expiredCoupons = couponRepository.findExpiredCoupons(LocalDateTime.now(mockClock));
+
+    // then
+    assertFalse(expiredCoupons.isEmpty());
+    assertEquals(savedCoupon.getId(), expiredCoupons.get(0).getId());
+  }
+
+
+}

--- a/service/coupon-domain/src/test/java/com/couponify/coupondomain/domain/CouponTest.java
+++ b/service/coupon-domain/src/test/java/com/couponify/coupondomain/domain/CouponTest.java
@@ -1,0 +1,108 @@
+package com.couponify.coupondomain.domain;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.couponify.coupondomain.domain.coupon.Coupon;
+import com.couponify.coupondomain.domain.coupon.CouponStatus;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class CouponTest {
+
+  final private String name = "샘플 쿠폰";
+  final private CouponStatus status = CouponStatus.AVAILABLE;
+  final private int quantity = 100;
+  final private int issueQuantity = 1;
+  final LocalDateTime issueStartAt = LocalDateTime.now().plusDays(1);
+  final LocalDateTime issueEndAt = LocalDateTime.now().plusDays(2);
+
+  @Test
+  @DisplayName("쿠폰 생성시 발급 시작 일시가 미래가 아닐 경우 예외가 발생한다.")
+  void constructWithInvalidIssueStartAtThrowsException() {
+    // given
+    final LocalDateTime issueStartAt = LocalDateTime.now().minusDays(1);
+
+    // when & then
+    assertThatThrownBy(() ->
+        Coupon.of(name, status, quantity, issueStartAt, issueEndAt))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("쿠폰 생성시 발급 종료 일시가 미래가 아닐 경우 예외가 발생한다.")
+  void constructWithInvalidIssueEndAtThrowsException() {
+    // given
+    final LocalDateTime issueStartAt = LocalDateTime.now().plusDays(1);
+    final LocalDateTime issueEndAt = LocalDateTime.now().plusDays(1);
+
+    // when & then
+    assertThatThrownBy(() ->
+        Coupon.of(name, status, quantity, issueStartAt, issueEndAt))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("쿠폰 생성시 발급 시작 일시와 종료 일시가 같을 경우 예외가 발생한다.")
+  void constructWithSameStartAndEndThrowsException() {
+    // given
+    final LocalDateTime issueEndAt = LocalDateTime.now().minusDays(1);
+
+    // when & then
+    assertThatThrownBy(() ->
+        Coupon.of(name, status, quantity, issueStartAt, issueEndAt))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("쿠폰 발급시 발급 가능한 기간이 아닐 경우 예외가 발생한다.")
+  void issueWithExpiredPeriodThrowsException() {
+    // given
+    Clock mockClock = mock(Clock.class);
+    LocalDateTime fixedNow = LocalDateTime.now();
+    when(mockClock.instant()).thenReturn(fixedNow.atZone(ZoneId.systemDefault()).toInstant());
+    when(mockClock.getZone()).thenReturn(ZoneId.systemDefault());
+
+    final LocalDateTime issueStartAt = LocalDateTime.now(mockClock).plusSeconds(1);
+    final LocalDateTime issueEndAt = issueStartAt.plusSeconds(1);
+
+    Coupon coupon = Coupon.of(name, status, quantity, issueStartAt, issueEndAt);
+
+    LocalDateTime afterPeriod = fixedNow.plusSeconds(3);
+    when(mockClock.instant()).thenReturn(afterPeriod.atZone(ZoneId.systemDefault()).toInstant());
+
+    // when & then
+    assertThatThrownBy(() ->
+        coupon.issue(issueQuantity))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("쿠폰 발급시 잔여 수량이 발급 수량보다 부족할 경우 예외가 발생한다.")
+  void issueWithInsufficientQuantityThrowsException() {
+    // given
+    final int quantity = 1;
+    Coupon coupon = Coupon.of(name, status, quantity, issueStartAt, issueEndAt);
+
+    // when & then
+    assertThatThrownBy(() ->
+        coupon.issue(quantity)).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("쿠폰 발급시 쿠폰이 '발급 가능' 상태가 아닐 경우 예외가 발생한다.")
+  void issueWithNotAvailableStatusThrowException() {
+    // given
+    final CouponStatus status = CouponStatus.SOLD_OUT;
+    Coupon coupon = Coupon.of(name, status, quantity, issueStartAt, issueEndAt);
+
+    // when & then
+    assertThatThrownBy(() ->
+        coupon.issue(quantity)).isInstanceOf(IllegalArgumentException.class);
+  }
+
+}

--- a/service/coupon-domain/src/test/java/com/couponify/coupondomain/domain/QuantityTest.java
+++ b/service/coupon-domain/src/test/java/com/couponify/coupondomain/domain/QuantityTest.java
@@ -1,0 +1,48 @@
+package com.couponify.coupondomain.domain;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.couponify.coupondomain.domain.coupon.Quantity;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class QuantityTest {
+
+  final private int initialValue = 1;
+
+  @Test
+  @DisplayName("수량 생성시 음수값을 넣을 경우 예외가 발생한다.")
+  void constructWithNegativeValueThrowsException() {
+    // given
+    final int wrongValue = -10;
+
+    // when & then
+    assertThatThrownBy(() -> new Quantity(wrongValue))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("수량 감소시 결과가 음수값일 경우 예외가 발생한다.")
+  void decreaseWithNegativeResultThrowsException() {
+    // given
+    final int decreaseValue = 10;
+    final Quantity quantity = new Quantity(initialValue);
+
+    // when & then
+    assertThatThrownBy(() -> quantity.decrease(decreaseValue))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("수량 증가시 결과가 음수값일 경우 예외가 발생한다.")
+  void increaseWithNegativeResultThrowsException() {
+    // given
+    final int increaseValue = -10;
+    final Quantity quantity = new Quantity(initialValue);
+
+    // when & then
+    assertThatThrownBy(() -> quantity.increase(increaseValue))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+}


### PR DESCRIPTION
## ✅ What is this PR

- 쿠폰 도메인, 리포지토리, 서비스에 대한 테스트 코드를 작성합니다.


## 📄 Changes Made

- **쿠폰 및 수량 도메인에 대한 테스트 작성**
  - 쿠폰 생성 시 필요한 유효성 검증(예: 만료일, 최소 조건 등)에 대한 테스트 작성
  - 수량 생성 시 허용 범위 및 조건을 검증하는 테스트 작성

- **쿠폰 리포지토리에 대한 테스트 작성**
  - 쿠폰 저장 성공 여부 테스트
  - 쿠폰 ID로 특정 쿠폰 조회 테스트
  - 만료된 쿠폰만 조회하는 쿼리의 정확성 검증 테스트

- **쿠폰 서비스에 대한 테스트 작성**
  - 신규 쿠폰 생성 로직 검증 테스트
  - 쿠폰 발급 시 중복 여부 및 조건 충족 여부 검증
  - 쿠폰 만료 처리 로직의 정확성 테스트

- **쿠폰 동시성 문제 발생 테스트 작성**
  - 100명의 사용자가 동시에 쿠폰을 발급할 때 발생하는 동시성 문제를 재현 및 확인하는 테스트 작성

## 🙋🏻‍ Review Point

> [쿠폰 동시성 문제 발생 테스트 시 데드락 발생](https://github.com/dev-couponify/docs/discussions/25)

## Test

> 스크린 샷 첨부
![image](https://github.com/user-attachments/assets/5a8b21c6-069c-4bff-aa2a-0930f02186f5)
![image](https://github.com/user-attachments/assets/4efa87c2-9ffa-4f4d-853e-be9613634a39)
- 수량 100개의 쿠폰을 100개 발급했지만 수량이 정상적으로 감소하지 않음


## Reference
- [외래키와 데드락](https://velog.io/@haron/%EC%99%B8%EB%9E%98%ED%82%A4Foreign-Key%EC%99%80-%EB%8D%B0%EB%93%9C%EB%9D%BDDeadLock-%EA%B7%B8%EB%A6%AC%EA%B3%A0-%EC%BF%BC%EB%A6%AC-%EC%A7%80%EC%97%B0-%EC%8B%A4%ED%96%89-eruedsy4)

## Issue
- close #13
