### PR TITLE
JPA 비관 락을 이용한 쿠폰 발급 동시성 제어

### DIFF
--- a/service/coupon-api/src/main/java/com/couponify/couponapi/application/CouponService.java
+++ b/service/coupon-api/src/main/java/com/couponify/couponapi/application/CouponService.java
@@ -36,7 +36,6 @@ public class CouponService {
   public Long issue(Long couponId, Long userId) {
     final Coupon coupon = validateCoupon(couponId);
     coupon.issue(QUANTITY_TO_ISSUE_COUPON);
-    couponRepository.flush();
 
     //TODO User 검증 필요
 
@@ -57,7 +56,7 @@ public class CouponService {
   }
 
   private Coupon validateCoupon(Long couponId) {
-    return couponRepository.findById(couponId).orElseThrow(
+    return couponRepository.findByIdForUpdate(couponId).orElseThrow(
         () -> new CouponException(CouponErrorCode.COUPON_NOT_FOUND, couponId)
     );
   }

--- a/service/coupon-api/src/test/java/com/couponify/couponapi/CouponFixture.java
+++ b/service/coupon-api/src/test/java/com/couponify/couponapi/CouponFixture.java
@@ -10,7 +10,7 @@ public class CouponFixture {
     final String name = "샘플 쿠폰";
     final CouponStatus status = CouponStatus.AVAILABLE;
     final int quantity = 100;
-    final LocalDateTime issueStartAt = LocalDateTime.now().plusDays(1);
+    final LocalDateTime issueStartAt = LocalDateTime.now().plusSeconds(1);
     final LocalDateTime issueEndAt = LocalDateTime.now().plusDays(2);
     return Coupon.of(name, status, quantity, issueStartAt, issueEndAt);
   }

--- a/service/coupon-api/src/test/java/com/couponify/couponapi/CouponFixture.java
+++ b/service/coupon-api/src/test/java/com/couponify/couponapi/CouponFixture.java
@@ -1,0 +1,18 @@
+package com.couponify.couponapi;
+
+import com.couponify.coupondomain.domain.coupon.Coupon;
+import com.couponify.coupondomain.domain.coupon.CouponStatus;
+import java.time.LocalDateTime;
+
+public class CouponFixture {
+
+  public static Coupon createCoupon() {
+    final String name = "샘플 쿠폰";
+    final CouponStatus status = CouponStatus.AVAILABLE;
+    final int quantity = 100;
+    final LocalDateTime issueStartAt = LocalDateTime.now().plusDays(1);
+    final LocalDateTime issueEndAt = LocalDateTime.now().plusDays(2);
+    return Coupon.of(name, status, quantity, issueStartAt, issueEndAt);
+  }
+
+}

--- a/service/coupon-api/src/test/java/com/couponify/couponapi/Integration/CouponConcurrentTest.java
+++ b/service/coupon-api/src/test/java/com/couponify/couponapi/Integration/CouponConcurrentTest.java
@@ -2,14 +2,11 @@ package com.couponify.couponapi.Integration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.couponify.couponapi.CouponFixture;
 import com.couponify.couponapi.application.CouponService;
-import com.couponify.couponapi.presentation.request.CouponCreateRequest;
 import com.couponify.coupondomain.domain.coupon.Coupon;
-import com.couponify.coupondomain.domain.coupon.CouponStatus;
 import com.couponify.coupondomain.domain.coupon.repository.CouponRepository;
 import com.couponify.coupondomain.domain.issuedCoupon.repository.IssuedCouponRepository;
-import java.time.LocalDateTime;
-import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -31,23 +28,17 @@ public class CouponConcurrentTest {
   @Test
   @DisplayName("100명의 사용자가 동시에 쿠폰을 발급할 때, 쿠폰 수량이 정상적으로 감소하고 100개의 쿠폰이 발급된다.")
   void issueCouponWith100Users() throws InterruptedException {
+    // given
     final int threadCount = 100;
-    final CouponCreateRequest request = new CouponCreateRequest(
-        "샘플 쿠폰",
-        CouponStatus.AVAILABLE,
-        100,
-        LocalDateTime.now().plusSeconds(1),
-        LocalDateTime.now().plusDays(3)
-    );
-    final Long couponId = couponRepository.save(CouponCreateRequest.toDomain(request)).getId();
+    final Long couponId = couponRepository.save(CouponFixture.createCoupon()).getId();
     final Long userId = 1L;
     final int expectedCouponQuantity = 0;
 
     Thread.sleep(1000);
-
     ExecutorService executor = Executors.newFixedThreadPool(threadCount);
     CountDownLatch latch = new CountDownLatch(threadCount);
 
+    // when
     for (int i = 0; i < threadCount; i++) {
       executor.submit(() -> {
         try {
@@ -62,8 +53,9 @@ public class CouponConcurrentTest {
     latch.await();
     executor.shutdown();
 
-    final Optional<Coupon> coupon = couponRepository.findById(couponId);
-    assertEquals(expectedCouponQuantity, coupon.get().getQuantity().getQuantity());
+    // then
+    final Coupon coupon = couponRepository.findById(couponId).orElseThrow();
+    assertEquals(expectedCouponQuantity, coupon.getQuantity());
   }
 
 

--- a/service/coupon-api/src/test/java/com/couponify/couponapi/Integration/CouponConcurrentTest.java
+++ b/service/coupon-api/src/test/java/com/couponify/couponapi/Integration/CouponConcurrentTest.java
@@ -1,6 +1,6 @@
 package com.couponify.couponapi.Integration;
 
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.couponify.couponapi.application.CouponService;
 import com.couponify.couponapi.presentation.request.CouponCreateRequest;
@@ -29,17 +29,16 @@ public class CouponConcurrentTest {
   private IssuedCouponRepository issuedCouponRepository;
 
   @Test
-  @DisplayName("100명의 사용자가 동시에 쿠폰을 발급할 수 있다.")
+  @DisplayName("100명의 사용자가 동시에 쿠폰을 발급할 때, 쿠폰 수량이 정상적으로 감소하고 100개의 쿠폰이 발급된다.")
   void issueCouponWith100Users() throws InterruptedException {
     final int threadCount = 100;
-    final CouponCreateRequest request = new CouponCreateRequest
-        (
-            "샘플 쿠폰",
-            CouponStatus.AVAILABLE,
-            100,
-            LocalDateTime.now().plusSeconds(1),
-            LocalDateTime.now().plusDays(3)
-        );
+    final CouponCreateRequest request = new CouponCreateRequest(
+        "샘플 쿠폰",
+        CouponStatus.AVAILABLE,
+        100,
+        LocalDateTime.now().plusSeconds(1),
+        LocalDateTime.now().plusDays(3)
+    );
     final Long couponId = couponRepository.save(CouponCreateRequest.toDomain(request)).getId();
     final Long userId = 1L;
     final int expectedCouponQuantity = 0;
@@ -64,7 +63,7 @@ public class CouponConcurrentTest {
     executor.shutdown();
 
     final Optional<Coupon> coupon = couponRepository.findById(couponId);
-    assertNotEquals(expectedCouponQuantity, coupon.get().getQuantity().getQuantity());
+    assertEquals(expectedCouponQuantity, coupon.get().getQuantity().getQuantity());
   }
 
 

--- a/service/coupon-domain/src/main/java/com/couponify/coupondomain/domain/coupon/Coupon.java
+++ b/service/coupon-domain/src/main/java/com/couponify/coupondomain/domain/coupon/Coupon.java
@@ -1,5 +1,6 @@
 package com.couponify.coupondomain.domain.coupon;
 
+import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -32,8 +33,11 @@ public class Coupon {
   @Enumerated(value = EnumType.STRING)
   private CouponStatus status;
 
-  @Column(nullable = false)
   @Embedded
+  @AttributeOverride(
+      name = "value",
+      column = @Column(name = "quantity", nullable = false)
+  )
   private Quantity quantity;
 
   @Column(nullable = false)

--- a/service/coupon-domain/src/main/java/com/couponify/coupondomain/domain/coupon/Coupon.java
+++ b/service/coupon-domain/src/main/java/com/couponify/coupondomain/domain/coupon/Coupon.java
@@ -71,7 +71,7 @@ public class Coupon {
   }
 
   private void validateSetPeriod(LocalDateTime issueStartAt, LocalDateTime issueEndAt) {
-    if (!isValidPeriod(issueStartAt, issueEndAt)) {
+    if (isNotValidPeriod(issueStartAt, issueEndAt)) {
       throw new IllegalArgumentException("쿠폰 생성시 발급 시작 일시와 종료 일시는 미래여야 합니다.");
     }
   }
@@ -80,6 +80,12 @@ public class Coupon {
     return (issueStartAt.isAfter(LocalDateTime.now()) &&
         issueEndAt.isAfter(LocalDateTime.now()) &&
         !issueStartAt.isEqual(issueEndAt));
+  }
+
+  private boolean isNotValidPeriod(LocalDateTime issueStartAt, LocalDateTime issueEndAt) {
+    return (!issueStartAt.isAfter(LocalDateTime.now()) ||
+        !issueEndAt.isAfter(LocalDateTime.now()) ||
+        issueStartAt.isEqual(issueEndAt));
   }
 
   private void updateStatus(CouponStatus newStatus) {

--- a/service/coupon-domain/src/main/java/com/couponify/coupondomain/domain/coupon/Coupon.java
+++ b/service/coupon-domain/src/main/java/com/couponify/coupondomain/domain/coupon/Coupon.java
@@ -66,6 +66,10 @@ public class Coupon {
     updateStatus(CouponStatus.EXPIRED);
   }
 
+  public int getQuantity() {
+    return this.quantity.getValue();
+  }
+
   private void validateSetPeriod(LocalDateTime issueStartAt, LocalDateTime issueEndAt) {
     if (!isValidPeriod(issueStartAt, issueEndAt)) {
       throw new IllegalArgumentException("쿠폰 생성시 발급 시작 일시와 종료 일시는 미래여야 합니다.");

--- a/service/coupon-domain/src/main/java/com/couponify/coupondomain/domain/coupon/Quantity.java
+++ b/service/coupon-domain/src/main/java/com/couponify/coupondomain/domain/coupon/Quantity.java
@@ -10,39 +10,39 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Quantity {
 
-  private int quantity;
+  private int value;
 
-  public Quantity(int quantity) {
-    validateQuantity(quantity);
-    this.quantity = quantity;
+  public Quantity(int value) {
+    validateValue(value);
+    this.value = value;
   }
 
   public void decrease(int amount) {
-    validateQuantity(this.quantity - amount);
-    this.quantity -= amount;
+    validateValue(this.value - amount);
+    this.value -= amount;
   }
 
   public void increase(int amount) {
-    validateQuantity(this.quantity + amount);
-    this.quantity += amount;
+    validateValue(this.value + amount);
+    this.value += amount;
   }
 
   public boolean isZero() {
-    return this.quantity == 0;
+    return this.value == 0;
   }
 
-  public boolean isGreaterThanOrEqualTo(int quantityToCompare) {
-    return this.quantity >= quantityToCompare;
+  public boolean isGreaterThanOrEqualTo(int valueToCompare) {
+    return this.value >= valueToCompare;
   }
 
-  private void validateQuantity(int quantity) {
-    if (isInvalidQuantity(quantity)) {
+  private void validateValue(int value) {
+    if (isInvalidValue(value)) {
       throw new IllegalArgumentException("쿠폰 수량은 0 이상이어야 합니다.");
     }
   }
 
-  private boolean isInvalidQuantity(int quantity) {
-    return quantity < 0;
+  private boolean isInvalidValue(int value) {
+    return value < 0;
   }
 
 }

--- a/service/coupon-domain/src/main/java/com/couponify/coupondomain/domain/coupon/repository/CouponRepository.java
+++ b/service/coupon-domain/src/main/java/com/couponify/coupondomain/domain/coupon/repository/CouponRepository.java
@@ -12,6 +12,8 @@ public interface CouponRepository {
 
   Optional<Coupon> findById(Long couponId);
 
+  Optional<Coupon> findByIdForUpdate(Long couponId);
+
   List<Coupon> findExpiredCoupons(LocalDateTime now);
 
   void flush();

--- a/service/coupon-domain/src/main/java/com/couponify/coupondomain/infrastructure/jpa/coupon/CouponRepositoryImpl.java
+++ b/service/coupon-domain/src/main/java/com/couponify/coupondomain/infrastructure/jpa/coupon/CouponRepositoryImpl.java
@@ -25,6 +25,11 @@ public class CouponRepositoryImpl implements CouponRepository {
   }
 
   @Override
+  public Optional<Coupon> findByIdForUpdate(Long couponId) {
+    return jpaCouponRepository.findByIdForUpdate(couponId);
+  }
+
+  @Override
   public List<Coupon> findExpiredCoupons(LocalDateTime now) {
     return jpaCouponRepository.findAllByIssueEndAtBefore(now);
   }

--- a/service/coupon-domain/src/main/java/com/couponify/coupondomain/infrastructure/jpa/coupon/JpaCouponRepository.java
+++ b/service/coupon-domain/src/main/java/com/couponify/coupondomain/infrastructure/jpa/coupon/JpaCouponRepository.java
@@ -1,12 +1,21 @@
 package com.couponify.coupondomain.infrastructure.jpa.coupon;
 
 import com.couponify.coupondomain.domain.coupon.Coupon;
+import jakarta.persistence.LockModeType;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface JpaCouponRepository extends JpaRepository<Coupon, Long> {
 
   List<Coupon> findAllByIssueEndAtBefore(LocalDateTime now);
+
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query("select c from Coupon c where c.id = :id")
+  Optional<Coupon> findByIdForUpdate(@Param("id") Long id);
 
 }

--- a/service/coupon-domain/src/test/java/com/couponify/coupondomain/domain/CouponRepositoryTest.java
+++ b/service/coupon-domain/src/test/java/com/couponify/coupondomain/domain/CouponRepositoryTest.java
@@ -9,8 +9,6 @@ import static org.mockito.Mockito.when;
 
 import com.couponify.coupondomain.domain.coupon.Coupon;
 import com.couponify.coupondomain.domain.coupon.repository.CouponRepository;
-import com.couponify.coupondomain.infrastructure.jpa.coupon.CouponRepositoryImpl;
-import com.couponify.coupondomain.infrastructure.jpa.coupon.JpaCouponRepository;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -21,25 +19,15 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 
+@Import(TestConfig.class)
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class CouponRepositoryTest {
 
   @Autowired
   private CouponRepository couponRepository;
-
-  @TestConfiguration
-  static class TestConfig {
-
-    @Bean
-    public CouponRepository couponRepository(JpaCouponRepository jpaCouponRepository) {
-      return new CouponRepositoryImpl(jpaCouponRepository);
-    } // JPA 빈이 아닌 빈을 등록하는 과정
-
-  }
 
   @Test
   @DisplayName("쿠폰을 저장할 수 있다.")

--- a/service/coupon-domain/src/test/java/com/couponify/coupondomain/domain/TestConfig.java
+++ b/service/coupon-domain/src/test/java/com/couponify/coupondomain/domain/TestConfig.java
@@ -1,0 +1,17 @@
+package com.couponify.coupondomain.domain;
+
+import com.couponify.coupondomain.domain.coupon.repository.CouponRepository;
+import com.couponify.coupondomain.infrastructure.jpa.coupon.CouponRepositoryImpl;
+import com.couponify.coupondomain.infrastructure.jpa.coupon.JpaCouponRepository;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class TestConfig {
+
+  @Bean
+  public CouponRepository couponRepository(JpaCouponRepository jpaCouponRepository) {
+    return new CouponRepositoryImpl(jpaCouponRepository);
+  }
+
+}


### PR DESCRIPTION
## ✅ What is this PR

- JPA 비관적 락을 이용하여 쿠폰 발급시 발생한 동시성 문제를 해결합니다.


### **📄 Changes Made**
- **JPA 비관적 락**을 적용하여 쿠폰 발급 시 동시성 제어 구현  
- 기존 동시성 문제 발생 검증 테스트를 수정하여 **동시성 제어 검증 테스트**로 변경  

- **쿠폰 동시성 테스트 및 리팩토링**  
  - **BDD 스타일**로 테스트 작성하여 가독성과 유지보수성 향상  
  - **CouponFixture** 추가로 테스트 데이터 관리 체계화  
  - `@Import`를 사용해 **테스트 설정 클래스**를 분리하여 테스트 환경을 독립적으로 관리  
  - **Coupon 클래스** 리팩토링:  
    1. `getQuantity` 메서드 추가로 잔여 수량 조회 간결화  
    2. 쿠폰 발급 기한 유효성을 확인하는 `isNotValidPeriod` 메서드 추가  
  - **Quantity 필드 네이밍 변경**:  
    - 기존 `quantity`에서 보다 명확한 의미를 전달하는 `value`로 수정  

## 🙋🏻‍ Reference
> [쿠폰 발급 시 발생한 데드락, 동시성 문제 해결](https://github.com/dev-couponify/docs/discussions/28)

## Test

- [x] JUnit 테스트 완료
> ![image](https://github.com/user-attachments/assets/7a354ff2-f084-45de-abfa-2110bbc3dfcb)


## Issue
- close #15
