### PR TITLE
비관적 락의 데드락 및 성능 병목 문제 개선을 위한 Redisson 분산 락 적용

### DIFF
--- a/service/coupon-api/build.gradle
+++ b/service/coupon-api/build.gradle
@@ -3,4 +3,5 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation("org.springframework:spring-tx")
+    implementation 'org.redisson:redisson-spring-boot-starter:3.41.0'
 }

--- a/service/coupon-api/src/main/java/com/couponify/couponapi/application/CouponLockService.java
+++ b/service/coupon-api/src/main/java/com/couponify/couponapi/application/CouponLockService.java
@@ -1,0 +1,38 @@
+package com.couponify.couponapi.application;
+
+import com.couponify.couponapi.exception.CouponErrorCode;
+import com.couponify.couponapi.exception.CouponException;
+import com.couponify.coupondomain.domain.coupon.repository.CouponRepository;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CouponLockService {
+
+  private final RedissonClient redissonClient;
+  private final CouponService couponService;
+  private final CouponRepository couponRepository;
+
+  public Long issueRLock(Long couponId, Long userId) {
+    RLock lock = redissonClient.getLock("issue:coupon:" + couponId);
+
+    try {
+      if (lock.tryLock(10, 5, TimeUnit.SECONDS)) {
+        return couponService.issue(couponId, userId);
+      } else {
+        throw new CouponException(CouponErrorCode.LOCK_ACQUISITION_FAILED);
+      }
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    } finally {
+      if (lock.isHeldByCurrentThread()) {
+        lock.unlock();
+      }
+    }
+  }
+
+}

--- a/service/coupon-api/src/main/java/com/couponify/couponapi/application/CouponService.java
+++ b/service/coupon-api/src/main/java/com/couponify/couponapi/application/CouponService.java
@@ -56,7 +56,7 @@ public class CouponService {
   }
 
   private Coupon validateCoupon(Long couponId) {
-    return couponRepository.findByIdForUpdate(couponId).orElseThrow(
+    return couponRepository.findById(couponId).orElseThrow(
         () -> new CouponException(CouponErrorCode.COUPON_NOT_FOUND, couponId)
     );
   }

--- a/service/coupon-api/src/main/java/com/couponify/couponapi/config/RedisConfig.java
+++ b/service/coupon-api/src/main/java/com/couponify/couponapi/config/RedisConfig.java
@@ -1,0 +1,37 @@
+package com.couponify.couponapi.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.redisson.spring.data.connection.RedissonConnectionFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedisConfig {
+
+  @Value("${spring.data.redis.host}")
+  private String host;
+
+  @Value("${spring.data.redis.port}")
+  private int port;
+
+  @Value("${spring.data.redis.password}")
+  private String password;
+
+  @Bean
+  public RedissonClient redissonClient() {
+    Config config = new Config();
+    config.useSingleServer()
+        .setAddress("redis://" + host + ":" + port)
+        .setPassword(password);
+    return Redisson.create(config);
+  }
+
+  @Bean
+  public RedissonConnectionFactory redissonConnectionFactory(RedissonClient redissonClient) {
+    return new RedissonConnectionFactory(redissonClient);
+  }
+
+}

--- a/service/coupon-api/src/main/java/com/couponify/couponapi/exception/CouponErrorCode.java
+++ b/service/coupon-api/src/main/java/com/couponify/couponapi/exception/CouponErrorCode.java
@@ -5,7 +5,8 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public enum CouponErrorCode {
-  COUPON_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 쿠폰입니다. : [%s]");
+  COUPON_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 쿠폰입니다. : [%s]"),
+  LOCK_ACQUISITION_FAILED(HttpStatus.LOCKED, "락을 획득할 수 없습니다.");
 
   private final HttpStatus status;
   private final String message;

--- a/service/coupon-api/src/main/java/com/couponify/couponapi/presentation/CouponController.java
+++ b/service/coupon-api/src/main/java/com/couponify/couponapi/presentation/CouponController.java
@@ -1,5 +1,6 @@
 package com.couponify.couponapi.presentation;
 
+import com.couponify.couponapi.application.CouponLockService;
 import com.couponify.couponapi.application.CouponService;
 import com.couponify.couponapi.presentation.request.CouponCreateRequest;
 import jakarta.validation.Valid;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class CouponController {
 
   private final CouponService couponService;
+  private final CouponLockService couponLockService;
 
   @PostMapping
   public ResponseEntity<Void> create(@Valid @RequestBody CouponCreateRequest couponCreateRequest) {
@@ -30,7 +32,7 @@ public class CouponController {
   public ResponseEntity<Void> issue(
       @PathVariable(name = "couponId") Long couponId,
       @RequestParam(name = "user-id") Long userId) {
-    Long savedIssuedCouponId = couponService.issue(couponId, userId);
+    Long savedIssuedCouponId = couponLockService.issueRLock(couponId, userId);
     return ResponseEntity.created(URI.create("/issuedCoupon/" + savedIssuedCouponId)).build();
   }
 

--- a/service/coupon-api/src/test/java/com/couponify/couponapi/Integration/CouponConcurrentTest.java
+++ b/service/coupon-api/src/test/java/com/couponify/couponapi/Integration/CouponConcurrentTest.java
@@ -3,6 +3,7 @@ package com.couponify.couponapi.Integration;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.couponify.couponapi.CouponFixture;
+import com.couponify.couponapi.application.CouponLockService;
 import com.couponify.couponapi.application.CouponService;
 import com.couponify.coupondomain.domain.coupon.Coupon;
 import com.couponify.coupondomain.domain.coupon.repository.CouponRepository;
@@ -20,6 +21,8 @@ public class CouponConcurrentTest {
 
   @Autowired
   private CouponService couponService;
+  @Autowired
+  private CouponLockService couponLockService;
   @Autowired
   private CouponRepository couponRepository;
   @Autowired
@@ -42,7 +45,7 @@ public class CouponConcurrentTest {
     for (int i = 0; i < threadCount; i++) {
       executor.submit(() -> {
         try {
-          couponService.issue(couponId, userId);
+          couponLockService.issueRLock(couponId, userId);
         } catch (Exception e) {
           e.printStackTrace();
         } finally {

--- a/service/coupon-domain/src/main/java/com/couponify/coupondomain/domain/coupon/repository/CouponRepository.java
+++ b/service/coupon-domain/src/main/java/com/couponify/coupondomain/domain/coupon/repository/CouponRepository.java
@@ -12,8 +12,6 @@ public interface CouponRepository {
 
   Optional<Coupon> findById(Long couponId);
 
-  Optional<Coupon> findByIdForUpdate(Long couponId);
-
   List<Coupon> findExpiredCoupons(LocalDateTime now);
 
   void flush();

--- a/service/coupon-domain/src/main/java/com/couponify/coupondomain/infrastructure/jpa/coupon/CouponRepositoryImpl.java
+++ b/service/coupon-domain/src/main/java/com/couponify/coupondomain/infrastructure/jpa/coupon/CouponRepositoryImpl.java
@@ -25,11 +25,6 @@ public class CouponRepositoryImpl implements CouponRepository {
   }
 
   @Override
-  public Optional<Coupon> findByIdForUpdate(Long couponId) {
-    return jpaCouponRepository.findByIdForUpdate(couponId);
-  }
-
-  @Override
   public List<Coupon> findExpiredCoupons(LocalDateTime now) {
     return jpaCouponRepository.findAllByIssueEndAtBefore(now);
   }

--- a/service/coupon-domain/src/main/java/com/couponify/coupondomain/infrastructure/jpa/coupon/JpaCouponRepository.java
+++ b/service/coupon-domain/src/main/java/com/couponify/coupondomain/infrastructure/jpa/coupon/JpaCouponRepository.java
@@ -1,21 +1,12 @@
 package com.couponify.coupondomain.infrastructure.jpa.coupon;
 
 import com.couponify.coupondomain.domain.coupon.Coupon;
-import jakarta.persistence.LockModeType;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface JpaCouponRepository extends JpaRepository<Coupon, Long> {
 
   List<Coupon> findAllByIssueEndAtBefore(LocalDateTime now);
-
-  @Lock(LockModeType.PESSIMISTIC_WRITE)
-  @Query("select c from Coupon c where c.id = :id")
-  Optional<Coupon> findByIdForUpdate(@Param("id") Long id);
 
 }

--- a/service/coupon-domain/src/main/resources/application-local.yml
+++ b/service/coupon-domain/src/main/resources/application-local.yml
@@ -3,3 +3,4 @@ spring:
     import:
       - classpath:properties/datasource.yml
       - classpath:properties/jpa.yml
+      - classpath:properties/redis.yml

--- a/service/coupon-domain/src/main/resources/properties/redis.yml
+++ b/service/coupon-domain/src/main/resources/properties/redis.yml
@@ -1,0 +1,6 @@
+spring:
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      password: "systempass"


### PR DESCRIPTION
## ✅ What is this PR

- Redisson 분산 락 적용을 통해 기존 비관적 락에서 발생할 수 있는 데드락과 성능 병목 문제를 개선합니다.


## 📄 Changes Made

- 관련 의존성 추가 (`redisson-spring-boot-starter`)
- Redis 설정 파일(`redis.yml`) 생성 및 구성
- **기존 비관적 락 코드 제거 및 Redisson 분산 락 적용**
- Redisson 락 `TTL` 설정으로 데드락 방지
- 락 획득 실패 시 처리 로직 추가 (`CouponErrorCode` 예외 코드 작성)
- 쿠폰 동시성 테스트 코드 수정 및 보완


## Test

- [x] Spring Boot JUnit 테스트 작성 및 실행 완료
- [x] 분산 락 적용 후 쿠폰 동시성 테스트 시 문제 없이 처리됨을 확인


## Reference
- [Redisson 분산락을 이용한 동시성 제어](https://velog.io/@hgs-study/redisson-distributed-lock)

## Issue
- close #18
